### PR TITLE
Add Cloudflare Worker to serve Go module mirrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.dist/
+.workers/
+.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
 # Go Module Proxy
+
+A Cloudflare Workers project that provides Go module metadata for selected modules
+and redirects `go get` requests to mirror repositories.
+
+## Features
+
+- Serves `<meta name="go-import">` and `<meta name="go-source">` tags for
+  configured modules so that `go` tooling fetches code from mirrored hosts.
+- Redirects human visitors to module documentation or repository pages.
+- Returns a helpful 404 page when a module mapping is missing.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start a local development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Deploy to Cloudflare Workers:
+
+   ```bash
+   npm run deploy
+   ```
+
+## Configure Module Mirrors
+
+Edit `MODULE_MIRRORS` in [`src/index.ts`](src/index.ts) to add, remove, or update
+module redirect rules. Each entry defines the Go import path prefix, the
+VCS/repository pair used by Go tooling, and optional source browsing and
+homepage URLs.
+
+Example entry:
+
+```ts
+{
+  module: "golang.org/x/mod",
+  vcs: "git",
+  repo: "https://go.googlesource.com/mod",
+  source: {
+    home: "https://cs.opensource.google/go/x/mod",
+    dir: "https://cs.opensource.google/go/x/mod/+/refs/heads/master/{dir}",
+    file: "https://cs.opensource.google/go/x/mod/+/refs/heads/master/{dir}/{file}#L{line}",
+  },
+  homepage: "https://pkg.go.dev/golang.org/x/mod",
+}
+```
+
+Requests such as
+`https://example.com/golang.org/x/mod?go-get=1` will receive the appropriate
+meta tags so that the Go toolchain downloads from `https://go.googlesource.com/mod`.
+Human visitors (without the `go-get=1` query parameter) will be redirected to the
+configured `homepage` URL when present.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "go-module-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "format": "prettier --write src/**/*.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240304.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.5",
+    "wrangler": "^3.51.0"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,168 @@
+export interface ModuleMirror {
+  /**
+   * Module import path prefix handled by this worker.
+   * e.g. `golang.org/x/mod`.
+   */
+  module: string;
+  /**
+   * Version control system type.
+   * Common values: `git`, `hg`, `svn`.
+   */
+  vcs: string;
+  /**
+   * Remote repository URL.
+   */
+  repo: string;
+  /**
+   * Optional source browser information for go-source meta tags.
+   */
+  source?: {
+    /** Base URL for browsing documentation. */
+    home: string;
+    /** Base URL for directory listings. */
+    dir: string;
+    /** Base URL for files. */
+    file: string;
+  };
+  /** Optional friendly landing page to redirect human visitors. */
+  homepage?: string;
+}
+
+const MODULE_MIRRORS: ModuleMirror[] = [
+  {
+    module: "golang.org/x/mod",
+    vcs: "git",
+    repo: "https://go.googlesource.com/mod",
+    source: {
+      home: "https://cs.opensource.google/go/x/mod",
+      dir: "https://cs.opensource.google/go/x/mod/+/refs/heads/master/{dir}",
+      file: "https://cs.opensource.google/go/x/mod/+/refs/heads/master/{dir}/{file}#L{line}",
+    },
+    homepage: "https://pkg.go.dev/golang.org/x/mod",
+  },
+  {
+    module: "golang.org/x/tools",
+    vcs: "git",
+    repo: "https://go.googlesource.com/tools",
+    source: {
+      home: "https://cs.opensource.google/go/x/tools",
+      dir: "https://cs.opensource.google/go/x/tools/+/refs/heads/master/{dir}",
+      file: "https://cs.opensource.google/go/x/tools/+/refs/heads/master/{dir}/{file}#L{line}",
+    },
+    homepage: "https://pkg.go.dev/golang.org/x/tools",
+  },
+];
+
+const MODULE_MIRRORS_BY_LENGTH = [...MODULE_MIRRORS].sort(
+  (a, b) => b.module.length - a.module.length,
+);
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const path = trimSlashes(url.pathname);
+    const moduleMirror = findModuleMirror(path);
+
+    if (!moduleMirror) {
+      return new Response(renderNotFound(path), {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    if (url.searchParams.get("go-get") === "1") {
+      return new Response(renderGoGetMeta(moduleMirror), {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    if (moduleMirror.homepage) {
+      return Response.redirect(moduleMirror.homepage, 302);
+    }
+
+    return new Response(renderLandingPage(moduleMirror), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  },
+};
+
+function trimSlashes(pathname: string): string {
+  return pathname.replace(/^\/+|\/+$/g, "");
+}
+
+function findModuleMirror(path: string): ModuleMirror | undefined {
+  if (path === "") {
+    return undefined;
+  }
+
+  // Compute the longest matching module prefix so that nested packages
+  // (e.g. golang.org/x/mod/module) resolve to the correct meta tags.
+  return MODULE_MIRRORS_BY_LENGTH.find(
+    ({ module }) => path === module || path.startsWith(`${module}/`),
+  );
+}
+
+function renderGoGetMeta({ module, vcs, repo, source }: ModuleMirror): string {
+  const goImport = `<meta name="go-import" content="${module} ${vcs} ${repo}">`;
+  const goSource = source
+    ? `<meta name="go-source" content="${module} ${source.home} ${source.dir} ${source.file}">`
+    : "";
+
+  return `<!DOCTYPE html><html lang="en"><head>${goImport}${goSource}</head><body></body></html>`;
+}
+
+function renderLandingPage(moduleMirror: ModuleMirror): string {
+  const { module, repo, homepage } = moduleMirror;
+  const description = `Redirects Go tooling to ${repo}.`;
+  const links = [
+    { href: repo, label: "Repository" },
+    homepage ? { href: homepage, label: "Documentation" } : undefined,
+  ].filter(Boolean) as { href: string; label: string }[];
+
+  const linksHtml = links
+    .map((link) => `<li><a href="${link.href}">${link.label}</a></li>`)
+    .join("");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${module}</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 3rem auto; max-width: 40rem; padding: 0 1.5rem; color: #1f2933; }
+      h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+      p { margin-bottom: 1.5rem; }
+      ul { list-style: none; padding: 0; }
+      li { margin-bottom: 0.5rem; }
+      a { color: #0b69a3; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <h1>${module}</h1>
+    <p>${description}</p>
+    <ul>${linksHtml}</ul>
+  </body>
+</html>`;
+}
+
+function renderNotFound(path: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Module Not Found</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 3rem auto; max-width: 40rem; padding: 0 1.5rem; color: #1f2933; }
+      a { color: #0b69a3; }
+    </style>
+  </head>
+  <body>
+    <h1>Module Not Found</h1>
+    <p>No module mapping was found for <code>${path}</code>.</p>
+    <p>Update <code>MODULE_MIRRORS</code> in <code>src/index.ts</code> to register a new module.</p>
+  </body>
+</html>`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022", "WebWorker"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "go-module-proxy"
+main = "src/index.ts"
+compatibility_date = "2023-10-10"
+usage_model = "bundled"
+
+[vars]
+# Example: set via `wrangler secret put` for private mirrors.


### PR DESCRIPTION
## Summary
- add a Cloudflare Workers handler that emits go-import/go-source meta tags and redirects human visitors for mirrored modules
- document how to configure module mirror mappings and bootstrap the worker project
- include project configuration (Wrangler, TypeScript, Prettier) and ignores for local tooling

## Testing
- npm install *(fails: 403 Forbidden fetching @cloudflare/workers-types in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8f5c6540832493663478cc6da7f7